### PR TITLE
allow removeAll to be a no-opp if there are no radio buttons

### DIFF
--- a/app/src/androidTest/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroupTest.java
+++ b/app/src/androidTest/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroupTest.java
@@ -1,0 +1,90 @@
+package com.whygraphics.multilineradiogroup;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(AndroidJUnit4.class)
+public class MultiLineRadioGroupTest {
+    @Test
+    public void removeAllButtonsHappyPath() throws Exception {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup testObject = new MultiLineRadioGroup(appContext);
+        testObject.addButtons("button one");
+
+        assertEquals("precondition, we have one button to remove", 1, testObject.getRadioButtonCount());
+
+        testObject.removeAllButtons();
+        assertEquals(0, testObject.getRadioButtonCount());
+    }
+
+    @Test
+    public void removeRangeOfButtonsHappyPath() throws Exception {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup testObject = new MultiLineRadioGroup(appContext);
+        testObject.addButtons("button one", "button two", "button three");
+        assertEquals("precondition, we have buttons", 3, testObject.getRadioButtonCount());
+
+        testObject.removeButtons(1, 1);
+
+        assertEquals(2, testObject.getRadioButtonCount());
+        assertEquals("button one", testObject.getRadioButtonAt(0).getText().toString());
+        assertEquals("button three", testObject.getRadioButtonAt(1).getText().toString());
+    }
+
+    @Test
+    public void removeButtons_ThrowsExceptionIfStartIsNegative() throws Exception {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup testObject = new MultiLineRadioGroup(appContext);
+        testObject.addButtons("button one", "button two", "button three");
+        assertEquals("precondition, we have buttons", 3, testObject.getRadioButtonCount());
+
+        try {
+            testObject.removeButtons(new Random().nextInt() * -1, 1);
+            fail("expected exception");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(3, testObject.getRadioButtonCount());
+        }
+    }
+
+    @Test
+    public void removeButtons_ThrowsExceptionIfStartIsBeyondSize() throws Exception {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup testObject = new MultiLineRadioGroup(appContext);
+        testObject.addButtons("button one", "button two", "button three");
+        assertEquals("precondition, we have buttons", 3, testObject.getRadioButtonCount());
+
+        try {
+            testObject.removeButtons(testObject.getRadioButtonCount(), 1);
+            fail("expected exception");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(3, testObject.getRadioButtonCount());
+        }
+    }
+
+    @Test
+    public void removeRangOfZeroButtonsWhenNoButtons() throws Exception {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup testObject = new MultiLineRadioGroup(appContext);
+
+        testObject.removeButtons(new Random().nextInt(), 0);
+    }
+
+    @Test
+    public void removeAllButtonsDoesNothingIfNoButtons() throws Exception {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup testObject = new MultiLineRadioGroup(appContext);
+
+        testObject.removeAllButtons();
+
+        assertEquals(0, testObject.getRadioButtonCount());
+    }
+}

--- a/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
+++ b/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
@@ -523,6 +523,9 @@ public class MultiLineRadioGroup extends RadioGroup {
      *                                  or count is negative
      */
     public void removeButtons(int start, int count) {
+        if (count == 0) {
+            return;
+        }
         if (start < 0 || start >= mRadioButtons.size())
             throw new IllegalArgumentException("start index must be between 0 to getRadioButtonCount() - 1 [" +
                     (getRadioButtonCount() - 1) + "]: " + start);

--- a/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
+++ b/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
@@ -532,10 +532,7 @@ public class MultiLineRadioGroup extends RadioGroup {
 
         if (count < 0)
             throw new IllegalArgumentException("count must not be negative: " + count);
-
-        if (count == 0)
-            return;
-
+        
         int endIndex = start + count - 1;
         // if endIndex is not in the range of the radio buttons sets it to the last index
         if (endIndex >= mRadioButtons.size())


### PR DESCRIPTION
When adding radio buttons programmatically, we need to always reset to a known empty state. Rather than make all clients check if the RadioGroup has buttons this allows the removeAllButtons() to be a no-opp.

backfill tests. 