### PR TITLE
OnCheckedChange is called for all clicks, not just changes.

### DIFF
--- a/app/src/androidTest/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroupTest.java
+++ b/app/src/androidTest/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroupTest.java
@@ -1,8 +1,12 @@
 package com.whygraphics.multilineradiogroup;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.view.ViewGroup;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -86,5 +90,70 @@ public class MultiLineRadioGroupTest {
         testObject.removeAllButtons();
 
         assertEquals(0, testObject.getRadioButtonCount());
+    }
+
+    @Test
+    public void baseRadioGroupClickAgainDoesNotEmitEvent() throws InterruptedException {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        RadioGroup radioGroup = new RadioGroup(appContext);
+        CountingOnCheckedChangeListener listener = new CountingOnCheckedChangeListener();
+        radioGroup.setOnCheckedChangeListener(listener);
+
+        clickAgainDoesNotEmitEvent(appContext, radioGroup);
+
+        assertEquals(1, listener.count);
+    }
+
+    @Test
+    public void multiLineRadioGroupClickAgainDoesNotEmitEvent() throws InterruptedException {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup radioGroup = new MultiLineRadioGroup(appContext);
+        MultilineOnCheckedChangeListener onCheckedChangeListener = new MultilineOnCheckedChangeListener();
+        radioGroup.setOnCheckedChangeListener(onCheckedChangeListener);
+
+        clickAgainDoesNotEmitEvent(appContext, radioGroup);
+
+        assertEquals(1, onCheckedChangeListener.count);
+    }
+
+    @SuppressLint("SetTextI18n")
+    private void clickAgainDoesNotEmitEvent(Context appContext, RadioGroup radioGroup) throws InterruptedException {
+        final RadioButton firstButton = new RadioButton(appContext);
+        firstButton.setText("first");
+        firstButton.setId(R.id.multi_line_radio_group_default_radio_button);
+        final RadioButton secondButton = new RadioButton(appContext);
+        secondButton.setText("second");
+        secondButton.setId(R.id.multi_line_radio_group_default_table_row);
+        radioGroup.addView(secondButton);
+
+        clickButton(secondButton);
+        clickButton(secondButton);
+    }
+
+    private void clickButton(final RadioButton radioButton) throws InterruptedException {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                radioButton.performClick();
+            }
+        });
+    }
+
+    private static class CountingOnCheckedChangeListener implements RadioGroup.OnCheckedChangeListener {
+        private int count;
+
+        @Override
+        public void onCheckedChanged(RadioGroup group, int checkedId) {
+            ++count;
+        }
+    }
+
+    private static class MultilineOnCheckedChangeListener implements MultiLineRadioGroup.OnCheckedChangeListener {
+        private int count;
+
+        @Override
+        public void onCheckedChanged(ViewGroup group, RadioButton button) {
+            ++count;
+        }
     }
 }

--- a/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
+++ b/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
@@ -407,10 +407,10 @@ public class MultiLineRadioGroup extends RadioGroup {
         radioButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                checkButton((RadioButton) v);
-
-                if (mOnCheckedChangeListener != null)
+                boolean didCheckStateChange = checkButton((RadioButton) v);
+                if (didCheckStateChange && mOnCheckedChangeListener != null) {
                     mOnCheckedChangeListener.onCheckedChanged(MultiLineRadioGroup.this, mCheckedButton);
+                }
             }
         });
     }
@@ -743,21 +743,21 @@ public class MultiLineRadioGroup extends RadioGroup {
         checkButton(mRadioButtons.get(index));
     }
 
-    // checks and switches the button with mCheckedButton
-    private void checkButton(RadioButton button) {
-        if (button == null)
-            return;
+    // checks and switches the button with mCheckedButton, returns true if check state changes
+    private boolean checkButton(RadioButton button) {
+        if (button == null || button == mCheckedButton) {
+            return false;
+        }
 
         // if the button to check is different from the current checked button
-        if (button != mCheckedButton) {
-
-            // if exists un-checks mCheckedButton
-            if (mCheckedButton != null)
-                mCheckedButton.setChecked(false);
-
-            button.setChecked(true);
-            mCheckedButton = button;
+        // if exists un-checks mCheckedButton
+        if (mCheckedButton != null) {
+            mCheckedButton.setChecked(false);
         }
+
+        button.setChecked(true);
+        mCheckedButton = button;
+        return true;
     }
 
     /**


### PR DESCRIPTION
with an interface method that is named the same as the parent class, the behaviour should be the same -- clicking the same radioButton should not emit a new 'onCheckChange' event since the _check_ state did not change when the same radio button is clicked. Tests show this is the behavior of the base RadioGroup class. 

While the listener interface is different, it has the same name as the base class. While this might be the object oriented design principle that is good to follow -- don't change behavior of a base method. There is a functional implication. Clients of the library that execute functionality upon _check change_ would only expect/want that functionality to execute once -- when the radio gets checked.