### PR TITLE
update restore instance state to avoid 'wrong state class' exception.

### DIFF
--- a/app/src/androidTest/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroupTest.java
+++ b/app/src/androidTest/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroupTest.java
@@ -2,6 +2,7 @@ package com.whygraphics.multilineradiogroup;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Parcelable;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.ViewGroup;
@@ -18,6 +19,20 @@ import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class MultiLineRadioGroupTest {
+
+    @Test
+    public void configChange() {
+
+
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        MultiLineRadioGroup testObject = new MultiLineRadioGroup(appContext);
+
+        Parcelable parcelable = testObject.onSaveInstanceState();
+
+        testObject.onRestoreInstanceState(parcelable);
+    }
+
+
     @Test
     public void removeAllButtonsHappyPath() throws Exception {
         Context appContext = InstrumentationRegistry.getTargetContext();

--- a/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
+++ b/app/src/main/java/com/whygraphics/multilineradiogroup/MultiLineRadioGroup.java
@@ -532,7 +532,7 @@ public class MultiLineRadioGroup extends RadioGroup {
 
         if (count < 0)
             throw new IllegalArgumentException("count must not be negative: " + count);
-        
+
         int endIndex = start + count - 1;
         // if endIndex is not in the range of the radio buttons sets it to the last index
         if (endIndex >= mRadioButtons.size())
@@ -833,13 +833,13 @@ public class MultiLineRadioGroup extends RadioGroup {
      */
     @Override
     protected void onRestoreInstanceState(Parcelable state) {
-        super.onRestoreInstanceState(state);
-
-        if (!(state instanceof SavedState))
+        if (!(state instanceof SavedState)) {
+            super.onRestoreInstanceState(state);
             return;
+        }
 
         SavedState savedState = (SavedState) state;
-
+        super.onRestoreInstanceState(savedState.getSuperState());
         setMaxInRow(savedState.mMaxInRow);
         checkAt(savedState.mCheckedButtonIndex);
     }


### PR DESCRIPTION
The current implementation of onRestoreInstanceState causes the following exception. By checking the type of the saved state we avoid this problem and use the superState when necessary. I loosely followed the example from [Tricky Android](http://trickyandroid.com/saving-android-view-state-correctly/) keeping the if condition you started with (as I've done on other custom controls)

> Wrong state class, expecting View State but received class com.whygraphics.multilineradiogroup.MultiLineRadioGroup$SavedState instead. This usually happens when two views of different type have the same id in the same hierarchy. This view's id is NO_ID. Make sure other views do not use the same id